### PR TITLE
Raised only when transactionStatusLabel is "REFUSED"

### DIFF
--- a/payzen/client.py
+++ b/payzen/client.py
@@ -137,9 +137,13 @@ class PayzenPaymentMixin:
             shopping_cart_request,
         )
 
-        if (response.commonResponse.responseCode == errors.SUCCESS and
-           response.commonResponse.transactionStatusLabel and
-           response.commonResponse.transactionStatusLabel != 'AUTHORISED'):
+        payment_refused = (
+            response.commonResponse.responseCode == errors.SUCCESS and
+            response.commonResponse.transactionStatusLabel and
+            response.commonResponse.transactionStatusLabel == 'REFUSED'
+        )
+
+        if payment_refused:
             raise PayzenPaymentRefused(response=response)
 
         return response


### PR DESCRIPTION
- On paypal payment, transactionStatusLabel is "COMPLETED" not "AUTHORISED"

But Payzen does not mention this label "COMPLETED" ...

https://payzen.io/fr-FR/webservices-payment/implementation-webservices-v5/1commonresponse.html 