### PR TITLE
[dependencies] suds-jurko==0.6 -> suds-community==1.1.0

### DIFF
--- a/payzen/__init__.py
+++ b/payzen/__init__.py
@@ -1,2 +1,2 @@
-__version__ = '0.0.11'
+__version__ = '0.0.12'
 __version_info__ = tuple(__version__.split('.'))

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'payzen.codes'
     ],
     install_requires=[
-        'suds-jurko==0.6'
+        'suds-community==1.1.0'
     ],
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This allows to use more recent python versions, since using suds-jurko==0.6 could not be installed with `setuptools>=58.0`.
See https://github.com/pypa/setuptools/issues/2784 for details.